### PR TITLE
Change the index setting so it can handle site in a directory

### DIFF
--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -55,7 +55,7 @@ class SP_API {
 	 */
 	public function setup() {
 		$url = get_site_url();
-		$this->index = preg_replace( '#^.*?//(.*?)/?$#', '$1', $url );
+		$this->index = str_replace ('/', '_', preg_replace( '#^.*?//(.*?)/?$#', '$1', $url ) );
 		$this->host = SP_Config()->get_setting( 'host' );
 		$this->request_defaults = array(
 			'sslverify'          => false,


### PR DESCRIPTION
localhost/wordpress as the index name confuses elasticsearch.  I've replaced the slashes with underscores.
