### PR TITLE
Fix indexing bug with orphan attachments

### DIFF
--- a/lib/class-sp-post.php
+++ b/lib/class-sp-post.php
@@ -285,7 +285,12 @@ class SP_Post extends SP_Indexable {
 
 		// Check post status
 		if ( 'inherit' === $this->data['post_status'] ) {
-			$post_status = $this->data['parent_status'];
+			if ( ! empty( $this->data['parent_status'] ) ) {
+				$post_status = $this->data['parent_status'];
+			} else {
+				// If the attachment doesn't have a post_parent, default to 'public'.
+				$post_status = 'publish';
+			}
 		} else {
 			$post_status = $this->data['post_status'];
 		}

--- a/lib/class-sp-post.php
+++ b/lib/class-sp-post.php
@@ -102,8 +102,14 @@ class SP_Post extends SP_Indexable {
 				unset( $this->data[ $field ] );
 			}
 		}
-	}
 
+		// If post status is inherit, but there's no parent status, index the
+		// parent status as 'publish'. This is a bit hacky, but required for
+		// proper indexing and searching.
+		if ( 'inherit' === $this->data['post_status'] && empty( $this->data['parent_status'] ) ) {
+			$this->data['parent_status'] = 'publish';
+		}
+	}
 
 	/**
 	 * Get post meta for a given post ID.
@@ -284,13 +290,8 @@ class SP_Post extends SP_Indexable {
 		}
 
 		// Check post status
-		if ( 'inherit' === $this->data['post_status'] ) {
-			if ( ! empty( $this->data['parent_status'] ) ) {
-				$post_status = $this->data['parent_status'];
-			} else {
-				// If the attachment doesn't have a post_parent, default to 'public'.
-				$post_status = 'publish';
-			}
+		if ( 'inherit' === $this->data['post_status'] && ! empty( $this->data['parent_status'] ) ) {
+			$post_status = $this->data['parent_status'];
 		} else {
 			$post_status = $this->data['post_status'];
 		}

--- a/tests/test-indexing.php
+++ b/tests/test-indexing.php
@@ -95,21 +95,56 @@ class Tests_Indexing extends SearchPress_UnitTestCase {
 		);
 	}
 
-	public function test_post_status_inherit() {
+	public function test_post_status_inherit_publish() {
 		$post_id = $this->factory->post->create();
 		$attachment_id = $this->factory->attachment->create_object( 'image.jpg', $post_id, array(
 			'post_mime_type' => 'image/jpeg',
 			'post_type'      => 'attachment',
 			'post_title'     => 'test attachment',
-			'post_name'      => 'test-attachment',
+			'post_name'      => 'test-attachment-1',
 		) );
 		SP_API()->post( '_refresh' );
 
 		// Test the searchability (and inherent indexability) of this status
 		$this->assertSame(
-			array( 'test-attachment' ),
+			array( 'test-attachment-1' ),
 			$this->search_and_get_field( array( 'query' => 'test attachment' ) ),
-			'Inherit status should be searchable'
+			'Inherit publish status should be searchable'
+		);
+	}
+
+	public function test_post_status_inherit_draft() {
+		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
+		$attachment_id = $this->factory->attachment->create_object( 'image.jpg', $post_id, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_type'      => 'attachment',
+			'post_title'     => 'test attachment',
+			'post_name'      => 'test-attachment-2',
+		) );
+		SP_API()->post( '_refresh' );
+
+		// Test the searchability (and inherent indexability) of this status
+		$this->assertSame(
+			array(),
+			$this->search_and_get_field( array( 'query' => 'test attachment' ) ),
+			'Inherit draft status should not be searchable'
+		);
+	}
+
+	public function test_orphan_post_status_inherit() {
+		$attachment_id = $this->factory->attachment->create_object( 'image.jpg', 0, array(
+			'post_mime_type' => 'image/jpeg',
+			'post_type'      => 'attachment',
+			'post_title'     => 'test attachment',
+			'post_name'      => 'test-attachment-3',
+		) );
+		SP_API()->post( '_refresh' );
+
+		// Test the searchability (and inherent indexability) of this status
+		$this->assertSame(
+			array( 'test-attachment-3' ),
+			$this->search_and_get_field( array( 'query' => 'test attachment' ) ),
+			'Inherit status without parent should be searchable'
 		);
 	}
 

--- a/tests/test-indexing.php
+++ b/tests/test-indexing.php
@@ -27,7 +27,7 @@ class Tests_Indexing extends SearchPress_UnitTestCase {
 			array( 'private',    true,  false ),
 			array( 'trash',      false, false ),
 			array( 'auto-draft', false, false ),
-			array( 'inherit',    false, false ), // 'inherit' without a parent
+			array( 'inherit',    true,  true ), // 'inherit' without a parent
 
 			// custom post statuses
 			array( 'cps-1',      false, false, array() ), // Assumed to be internal


### PR DESCRIPTION
This addresses an indexing and search bug that appears when a user uploads an attachment directly to the media library and not to the media modal on the edit post screen.