### PR TITLE
Hotfix: Disable APC found_posts filters while running cron

### DIFF
--- a/lib/class-sp-compat.php
+++ b/lib/class-sp-compat.php
@@ -46,3 +46,5 @@ class SP_Compat extends SP_Singleton {
 function SP_Compat() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	return SP_Compat::instance();
 }
+
+SP_Compat();

--- a/lib/class-sp-compat.php
+++ b/lib/class-sp-compat.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * SearchPress library: SP_Compat class
+ *
+ * @package SearchPress
+ */
+
+/**
+ * Action hook and filter callbacks for compatibility with other plugins.
+ */
+class SP_Compat extends SP_Singleton {
+
+	/**
+	 * Advanced Post Cache can periodically return the wrong value for
+	 * found_posts, which can cause the reindex operation to abort prematurely.
+	 * We will unhook it before indexing to prevent this.
+	 */
+	public function action_sp_pre_index_loop() {
+		global $advanced_post_cache_object;
+
+		if ( ! empty( $advanced_post_cache_object ) ) {
+			remove_filter(
+				'found_posts',
+				array( $advanced_post_cache_object, 'found_posts' )
+			);
+			remove_filter(
+				'found_posts_query',
+				array( $advanced_post_cache_object, 'found_posts_query' )
+			);
+		}
+	}
+
+	/**
+	 * Setup the actions for this singleton.
+	 */
+	public function setup() {
+		add_action( 'sp_pre_index_loop', array( $this, 'action_sp_pre_index_loop' ) );
+	}
+}
+
+/**
+ * Returns an initialized instance of the SP_Compat class.
+ *
+ * @return SP_Compat An initialized instance of the SP_Compat class.
+ */
+function SP_Compat() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+	return SP_Compat::instance();
+}

--- a/lib/class-sp-sync-manager.php
+++ b/lib/class-sp-sync-manager.php
@@ -166,25 +166,15 @@ class SP_Sync_Manager extends SP_Singleton {
 	 * @return bool
 	 */
 	public function do_index_loop() {
-
 		/**
-		 * Advanced Post Cache can periodically return the wrong value for
-		 * found_posts, which can cause the reindex operation to abort prematurely.
-		 * We will unhook it during cron to prevent this.
+		 * Action hook that fires before the index loop starts.
+		 *
+		 * Provides an opportunity to unhook actions that are incompatible with
+		 * the index loop.
+		 *
+		 * @since 0.3.0
 		 */
-		if ( wp_doing_cron() && class_exists( 'Advanced_Post_Cache' ) ) {
-			global $advanced_post_cache_object;
-			if ( ! empty( $advanced_post_cache_object ) ) {
-				remove_filter(
-					'found_posts',
-					array( $advanced_post_cache_object, 'found_posts' )
-				);
-				remove_filter(
-					'found_posts_query',
-					array( $advanced_post_cache_object, 'found_posts_query' )
-				);
-			}
-		}
+		do_action( 'sp_pre_index_loop' );
 
 		$sync_meta = SP_Sync_Meta();
 

--- a/lib/class-sp-sync-manager.php
+++ b/lib/class-sp-sync-manager.php
@@ -166,6 +166,26 @@ class SP_Sync_Manager extends SP_Singleton {
 	 * @return bool
 	 */
 	public function do_index_loop() {
+
+		/**
+		 * Advanced Post Cache can periodically return the wrong value for
+		 * found_posts, which can cause the reindex operation to abort prematurely.
+		 * We will unhook it during cron to prevent this.
+		 */
+		if ( wp_doing_cron() && class_exists( 'Advanced_Post_Cache' ) ) {
+			global $advanced_post_cache_object;
+			if ( ! empty( $advanced_post_cache_object ) ) {
+				remove_filter(
+					'found_posts',
+					array( $advanced_post_cache_object, 'found_posts' )
+				);
+				remove_filter(
+					'found_posts_query',
+					array( $advanced_post_cache_object, 'found_posts_query' )
+				);
+			}
+		}
+
 		$sync_meta = SP_Sync_Meta();
 
 		$start = $sync_meta->page * $sync_meta->bulk;

--- a/searchpress.php
+++ b/searchpress.php
@@ -63,6 +63,9 @@ require_once SP_PLUGIN_DIR . '/lib/class-sp-post.php';
 // A controller for syncing content across to ES.
 require_once SP_PLUGIN_DIR . '/lib/class-sp-sync-manager.php';
 
+// Handles compatibility with other plugins.
+require_once SP_PLUGIN_DIR . '/lib/class-sp-compat.php';
+
 // Manages all cron processes.
 require_once SP_PLUGIN_DIR . '/lib/class-sp-cron.php';
 


### PR DESCRIPTION
Under certain circumstances, the Advanced Post Cache filters for `found_posts` can return the incorrect number of found posts for the Searchpress index query, causing it to prematurely abort. This PR unhooks the APC `found_posts` filters while cron is running an indexing operation.