### PR TITLE
Move postmeta indexing to be opt-in for performance

### DIFF
--- a/lib/class-sp-config.php
+++ b/lib/class-sp-config.php
@@ -189,9 +189,17 @@ class SP_Config extends SP_Singleton {
 									'long'     => array( 'type' => 'long' ),
 									'double'   => array( 'type' => 'double' ),
 									'boolean'  => array( 'type' => 'boolean' ),
+									'date'     => array(
+										'type'   => 'date',
+										'format' => 'YYYY-MM-dd',
+									),
 									'datetime' => array(
 										'type'   => 'date',
 										'format' => 'YYYY-MM-dd HH:mm:ss',
+									),
+									'time'     => array(
+										'type'   => 'date',
+										'format' => 'HH:mm:ss',
 									),
 								),
 							),

--- a/lib/class-sp-config.php
+++ b/lib/class-sp-config.php
@@ -189,17 +189,9 @@ class SP_Config extends SP_Singleton {
 									'long'     => array( 'type' => 'long' ),
 									'double'   => array( 'type' => 'double' ),
 									'boolean'  => array( 'type' => 'boolean' ),
-									'date'     => array(
-										'type'   => 'date',
-										'format' => 'YYYY-MM-dd',
-									),
 									'datetime' => array(
 										'type'   => 'date',
 										'format' => 'YYYY-MM-dd HH:mm:ss',
-									),
-									'time'     => array(
-										'type'   => 'date',
-										'format' => 'HH:mm:ss',
 									),
 								),
 							),

--- a/lib/class-sp-indexable.php
+++ b/lib/class-sp-indexable.php
@@ -87,9 +87,7 @@ abstract class SP_Indexable {
 		}
 
 		if ( false !== $time ) {
-			$return['date']     = gmdate( 'Y-m-d', $time );
 			$return['datetime'] = gmdate( 'Y-m-d H:i:s', $time );
-			$return['time']     = gmdate( 'H:i:s', $time );
 		}
 
 		return $return;

--- a/lib/class-sp-indexable.php
+++ b/lib/class-sp-indexable.php
@@ -42,52 +42,74 @@ abstract class SP_Indexable {
 	/**
 	 * Split the meta values into different types for meta query casting.
 	 *
-	 * @param  string $value Meta value.
+	 * @param string $value Meta value.
+	 * @param array  $types Data types to cast to, e.g. ['value', 'raw'].
 	 * @return array
 	 */
-	public static function cast_meta_types( $value ) {
-		$return = array(
-			'value'   => $value,
-			'raw'     => $value,
-			'boolean' => (bool) $value,
-		);
-
-		$time   = false;
-		$double = floatval( $value );
-		if ( is_numeric( $value ) && is_finite( $double ) ) {
-			$int              = intval( $value );
-			$return['long']   = $int;
-			$return['double'] = $double;
-
-			/*
-			 * If this is an integer (represented as a string), check to see if
-			 * it is a valid timestamp.
-			 */
-			if ( (string) $int === (string) $value ) {
-				$year = intval( gmdate( 'Y', $int ) );
-				// Ensure that the year is between 1-2038. Technically, the year
-				// range ES allows is 1-292278993, but PHP ints limit us to 2038.
-				if ( $year > 0 && $year < 2039 ) {
-					$time = $int;
-				}
-			}
-		} elseif ( is_string( $value ) ) {
-			$return['value'] = self::limit_word_length( $value );
-			$return['raw']   = self::limit_string( $value );
-
-			// Correct boolean values.
-			if ( 'false' === strtolower( $value ) ) {
-				$return['boolean'] = false;
-			} elseif ( 'true' === strtolower( $value ) ) {
-				$return['boolean'] = true;
-			}
-
-			// add date/time if we have it.
-			$time = strtotime( $value );
+	public static function cast_meta_types( $value, $types = array() ) {
+		// Ensure value is scalar before attempting to type cast it.
+		if ( isset( $value ) && ! is_scalar( $value ) ) {
+			return array();
 		}
 
-		if ( false !== $time ) {
-			$return['datetime'] = gmdate( 'Y-m-d H:i:s', $time );
+		$types  = array_fill_keys( $types, true );
+		$return = array();
+
+		if ( isset( $types['value'] ) ) {
+			$return['value'] = isset( $value )
+				? self::limit_word_length( (string) $value )
+				: null;
+		}
+		if ( isset( $types['raw'] ) ) {
+			$return['raw'] = isset( $value )
+				? self::limit_string( (string) $value )
+				: null;
+		}
+		if ( isset( $types['long'] ) && is_numeric( $value ) && $value <= PHP_INT_MAX ) {
+			$return['long'] = (int) $value;
+			if ( ! is_finite( $return['long'] ) ) {
+				unset( $return['long'] );
+			}
+		}
+		if ( isset( $types['double'] ) && is_numeric( $value ) && $value <= PHP_FLOAT_MAX ) {
+			$return['double'] = (float) $value;
+			if ( ! is_finite( $return['double'] ) ) {
+				unset( $return['double'] );
+			}
+		}
+		if ( isset( $types['boolean'] ) ) {
+			// Correct boolean values.
+			if ( is_string( $value ) && 'false' === strtolower( $value ) ) {
+				$return['boolean'] = false;
+			} else {
+				$return['boolean'] = (bool) $value;
+			}
+		}
+		if (
+			( isset( $types['date'] ) || isset( $types['datetime'] ) || isset( $types['time'] ) )
+			&& strlen( $value ) <= 255 // Limit date/time strings to 255 chars for performance.
+		) {
+			$time = false;
+			$int  = (int) $value;
+
+			// Check to see if this is a timestamp.
+			if ( (string) $int === (string) $value ) {
+				$time = $int;
+			} elseif ( ! is_numeric( $value ) ) {
+				$time = strtotime( $value );
+			}
+
+			if ( false !== $time ) {
+				if ( isset( $types['date'] ) ) {
+					$return['date'] = gmdate( 'Y-m-d', $time );
+				}
+				if ( isset( $types['datetime'] ) ) {
+					$return['datetime'] = gmdate( 'Y-m-d H:i:s', $time );
+				}
+				if ( isset( $types['time'] ) ) {
+					$return['time'] = gmdate( 'H:i:s', $time );
+				}
+			}
 		}
 
 		return $return;

--- a/lib/class-sp-indexable.php
+++ b/lib/class-sp-indexable.php
@@ -71,7 +71,7 @@ abstract class SP_Indexable {
 				unset( $return['long'] );
 			}
 		}
-		if ( isset( $types['double'] ) && is_numeric( $value ) && $value <= PHP_FLOAT_MAX ) {
+		if ( isset( $types['double'] ) && is_numeric( $value ) ) {
 			$return['double'] = (float) $value;
 			if ( ! is_finite( $return['double'] ) ) {
 				unset( $return['double'] );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -66,4 +66,8 @@
 			</property>
 		</properties>
 	</rule>
+
+	<rule ref="WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant">
+		<exclude-pattern>./searchpress.php</exclude-pattern>
+	</rule>
 </ruleset>

--- a/searchpress.php
+++ b/searchpress.php
@@ -26,9 +26,6 @@
 	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-// Whitelist the SP_PLUGIN_DIR constant for use in file inclusion.
-// phpcs:disable WordPressVIPMinimum.Files.IncludingFile.UsingCustomConstant
-
 if ( ! defined( 'SP_PLUGIN_URL' ) ) {
 	define( 'SP_PLUGIN_URL', plugins_url( '/', __FILE__ ) );
 }

--- a/tests/test-mapping-postmeta.php
+++ b/tests/test-mapping-postmeta.php
@@ -18,11 +18,11 @@ class Tests_Mapping_Postmeta extends SearchPress_UnitTestCase {
 		parent::setUp();
 
 		add_filter(
-			'sp_post_meta_whitelist',
-			function( $meta_whitelist ) {
+			'sp_post_allowed_meta',
+			function() {
 				return array(
-					'mapping_postmeta_test',
-					'long_string_test',
+					'mapping_postmeta_test' => array( 'value', 'raw', 'boolean', 'long', 'double', 'date', 'datetime', 'time' ),
+					'long_string_test'      => array( 'value', 'raw' ),
 				);
 			}
 		);

--- a/tests/test-mapping-postmeta.php
+++ b/tests/test-mapping-postmeta.php
@@ -14,6 +14,20 @@ class Tests_Mapping_Postmeta extends SearchPress_UnitTestCase {
 		self::$demo_post_id = self::factory()->post->create();
 	}
 
+	public function setUp() {
+		parent::setUp();
+
+		add_filter(
+			'sp_post_meta_whitelist',
+			function( $meta_whitelist ) {
+				return array(
+					'mapping_postmeta_test',
+					'long_string_test',
+				);
+			}
+		);
+	}
+
 	public function tearDown() {
 		delete_post_meta( self::$demo_post_id, 'mapping_postmeta_test' );
 		delete_post_meta( self::$demo_post_id, 'long_string_test' );
@@ -87,12 +101,8 @@ class Tests_Mapping_Postmeta extends SearchPress_UnitTestCase {
 		if ( isset( $datetime ) ) {
 			list( $date, $time ) = explode( ' ', $datetime );
 			$this->assertSame( array( $datetime ), $this->search_and_get_field( array(), 'post_meta.mapping_postmeta_test.datetime' ), 'Checking meta.datetime' );
-			$this->assertSame( array( $date ), $this->search_and_get_field( array(), 'post_meta.mapping_postmeta_test.date' ), 'Checking meta.date' );
-			$this->assertSame( array( $time ), $this->search_and_get_field( array(), 'post_meta.mapping_postmeta_test.time' ), 'Checking meta.time' );
 		} else {
 			$this->assertSame( array(), $this->search_and_get_field( array(), 'post_meta.mapping_postmeta_test.datetime' ), 'Checking that meta.datetime is missing' );
-			$this->assertSame( array(), $this->search_and_get_field( array(), 'post_meta.mapping_postmeta_test.date' ), 'Checking that meta.date is missing' );
-			$this->assertSame( array(), $this->search_and_get_field( array(), 'post_meta.mapping_postmeta_test.time' ), 'Checking that meta.time is missing' );
 		}
 	}
 

--- a/tests/test-mapping.php
+++ b/tests/test-mapping.php
@@ -16,15 +16,15 @@ class Tests_Mapping extends SearchPress_UnitTestCase {
 		parent::setUpBeforeClass();
 
 		add_filter(
-			'sp_post_meta_whitelist',
-			function( $meta_whitelist ) {
+			'sp_post_allowed_meta',
+			function() {
 				return array(
-					'test_string',
-					'test_long',
-					'test_double',
-					'test_boolean_true',
-					'test_boolean_false',
-					'test_date',
+					'test_string'        => array( 'value', 'raw' ),
+					'test_long'          => array( 'long' ),
+					'test_double'        => array( 'double' ),
+					'test_boolean_true'  => array( 'boolean' ),
+					'test_boolean_false' => array( 'boolean' ),
+					'test_date'          => array( 'date', 'datetime', 'time' ),
 				);
 			}
 		);

--- a/tests/test-mapping.php
+++ b/tests/test-mapping.php
@@ -15,6 +15,20 @@ class Tests_Mapping extends SearchPress_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
+		add_filter(
+			'sp_post_meta_whitelist',
+			function( $meta_whitelist ) {
+				return array(
+					'test_string',
+					'test_long',
+					'test_double',
+					'test_boolean_true',
+					'test_boolean_false',
+					'test_date',
+				);
+			}
+		);
+
 		self::$demo_user = array(
 			'user_login'    => 'author1',
 			'user_nicename' => 'author-nicename',
@@ -274,18 +288,8 @@ class Tests_Mapping extends SearchPress_UnitTestCase {
 		);
 
 		$this->assertSame(
-			array( '2012-03-14' ),
-			$this->search_and_get_field( array(), 'post_meta.test_date.date' )
-		);
-
-		$this->assertSame(
 			array( '2012-03-14 03:14:15' ),
 			$this->search_and_get_field( array(), 'post_meta.test_date.datetime' )
-		);
-
-		$this->assertSame(
-			array( '03:14:15' ),
-			$this->search_and_get_field( array(), 'post_meta.test_date.time' )
 		);
 	}
 

--- a/tests/test-post.php
+++ b/tests/test-post.php
@@ -9,6 +9,16 @@ class Tests_Post extends WP_UnitTestCase {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
+		add_filter(
+			'sp_post_meta_whitelist',
+			function( $meta_whitelist ) {
+				return array(
+					'_test_key_1',
+					'_test_key_2',
+				);
+			}
+		);
+
 		$cat_a = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'cat-a' ) );
 		$cat_b = self::factory()->term->create( array( 'taxonomy' => 'category', 'name' => 'cat-b' ) );
 
@@ -30,6 +40,7 @@ class Tests_Post extends WP_UnitTestCase {
 		$this->assertEquals( 'lorem-ipsum', self::$sp_post->post_name );
 		$this->assertEquals( 'test meta string', self::$sp_post->post_meta['_test_key_1'][0]['raw'] );
 		$this->assertEquals( 721, self::$sp_post->post_meta['_test_key_2'][0]['long'] );
+		$this->assertArrayNotHasKey( '_test_key_3', self::$sp_post->post_meta );
 		$this->assertEquals( 'cat-a', self::$sp_post->terms['category'][0]['slug'] );
 	}
 

--- a/tests/test-post.php
+++ b/tests/test-post.php
@@ -10,11 +10,12 @@ class Tests_Post extends WP_UnitTestCase {
 		parent::setUpBeforeClass();
 
 		add_filter(
-			'sp_post_meta_whitelist',
-			function( $meta_whitelist ) {
+			'sp_post_allowed_meta',
+			function( $allowed_meta ) {
 				return array(
-					'_test_key_1',
-					'_test_key_2',
+					'_test_key_1' => [ 'value' ],
+					'_test_key_2' => [ 'long', 'double' ],
+					'_test_key_3' => [ 'date', 'datetime' ], // Invalid.
 				);
 			}
 		);
@@ -29,7 +30,7 @@ class Tests_Post extends WP_UnitTestCase {
 			'post_category' => array( $cat_a, $cat_b ),
 		) );
 		update_post_meta( $post_id, '_test_key_1', 'test meta string' );
-		update_post_meta( $post_id, '_test_key_2', 721 );
+		update_post_meta( $post_id, '_test_key_2', 721.8 );
 		update_post_meta( $post_id, '_test_key_3', array( 'foo' => array( 'bar' => array( 'bat' => true ) ) ) );
 
 		$post = get_post( $post_id );
@@ -38,9 +39,15 @@ class Tests_Post extends WP_UnitTestCase {
 
 	function test_getting_attributes() {
 		$this->assertEquals( 'lorem-ipsum', self::$sp_post->post_name );
-		$this->assertEquals( 'test meta string', self::$sp_post->post_meta['_test_key_1'][0]['raw'] );
-		$this->assertEquals( 721, self::$sp_post->post_meta['_test_key_2'][0]['long'] );
-		$this->assertArrayNotHasKey( '_test_key_3', self::$sp_post->post_meta );
+		$meta = self::$sp_post->post_meta;
+		$this->assertCount( 1, $meta['_test_key_1'] );
+		$this->assertCount( 1, $meta['_test_key_1'][0] );
+		$this->assertCount( 1, $meta['_test_key_2'] );
+		$this->assertCount( 2, $meta['_test_key_2'][0] );
+		$this->assertEquals( 'test meta string', $meta['_test_key_1'][0]['value'] );
+		$this->assertEquals( 721, $meta['_test_key_2'][0]['long'] );
+		$this->assertEquals( 721.8, $meta['_test_key_2'][0]['double'] );
+		$this->assertArrayNotHasKey( '_test_key_3', $meta );
 		$this->assertEquals( 'cat-a', self::$sp_post->terms['category'][0]['slug'] );
 	}
 


### PR DESCRIPTION
**Note: This is a significant and breaking change to post indexing.**

This PR changes SearchPress from indexing almost all post meta to indexing only the post meta that a site's developer explicitly plans to use. Further, it only indexes post meta in the _data types_ that a site's developer plans to use. The principle reason behind this change is performance, and to prevent ["mappings explosion"](https://www.elastic.co/guide/en/elasticsearch/reference/master/mapping.html#mapping-limit-settings).

Details of this change will be documented in the README along with others in the 0.4 release.

Resolves #101.