### PR TITLE
Update doc type mapping for ES < 7.0

### DIFF
--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -93,12 +93,8 @@ class SP_API extends SP_Singleton {
 	 * @return string
 	 */
 	public function get_doc_type() {
-		if ( empty( $this->doc_type ) ) {
-			if ( sp_es_version_compare( '6.0', '<' ) ) {
-				$this->doc_type = 'post';
-			} else {
-				$this->doc_type = '_doc';
-			}
+		if ( empty( $this->doc_type ) && sp_es_version_compare( '7.0', '<' ) ) {
+			$this->doc_type = 'post';
 		}
 
 		return $this->doc_type;


### PR DESCRIPTION
Ensure the doc type used for ES clusters < 7.0 is `post`