### PR TITLE
add notes about deprecated/removed filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Changelog
 ### 0.4
 
 * **CRITICAL BREAKING CHANGE:** Post meta indexing is now opt-in. See README for more information.
+* **POTENTIAL BREAKING CHANGE:** Removes `sp_post_indexable_meta` filter
+* Removes `sp_post_ignored_postmeta` filter
 * Adds support for ES 5.x, 6.x, 7.x
 * Fixes indexing bug with parentless attachments
 * Fixes a bug with bulk syncing attachments


### PR DESCRIPTION
Two filters were removed with [v0.4](https://github.com/alleyinteractive/searchpress/releases/tag/v0.4) that were undocumented. This PR makes these removals visible.