### PR TITLE
filter index single post path

### DIFF
--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -256,7 +256,8 @@ class SP_API extends SP_Singleton {
 		/**
 		 * Filter the index path for single posts.
 		 *
-		 * @param string $post_index_path Bulk index path.
+		 * @param string   $post_index_path Single post index path.
+		 * @param \WP_Post $post            Post Object.
 		 */
 		$post_index_path = apply_filters( 'sp_post_index_path', "{$this->get_doc_type()}/{$post->post_id}", $post );
 		return $this->put( $post_index_path, $json );

--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -252,7 +252,14 @@ class SP_API extends SP_Singleton {
 		if ( empty( $json ) ) {
 			return new WP_Error( 'invalid-json', __( 'Invalid JSON', 'searchpress' ) );
 		}
-		return $this->put( "{$this->get_doc_type()}/{$post->post_id}", $json );
+		
+		/**
+		 * Filter the index path for single posts.
+		 *
+		 * @param string $post_index_path Bulk index path.
+		 */
+		$post_index_path = apply_filters( 'sp_post_index_path', "{$this->get_doc_type()}/{$post->post_id}", $post );
+		return $this->put( $post_index_path, $json );
 	}
 
 	/**


### PR DESCRIPTION
As titled. This filter is particularly helpful, for example, if a pipeline needs to be added to an index operation.
