### PR TITLE
Handle batch with no indexable posts

### DIFF
--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -293,7 +293,7 @@ class SP_API extends SP_Singleton {
 
 		// If no posts should be indexed, return an empty response.
 		if ( empty( $body ) ) {
-			return (object) [ 'items' => [] ];
+			return (object) array( 'items' => array() );
 		}
 
 		/**

--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -252,7 +252,7 @@ class SP_API extends SP_Singleton {
 		if ( empty( $json ) ) {
 			return new WP_Error( 'invalid-json', __( 'Invalid JSON', 'searchpress' ) );
 		}
-		
+
 		/**
 		 * Filter the index path for single posts.
 		 *
@@ -290,7 +290,12 @@ class SP_API extends SP_Singleton {
 				$body[] = addcslashes( $json, "\n" );
 			}
 		}
-		
+
+		// If no posts should be indexed, return an empty response.
+		if ( empty( $body ) ) {
+			return (object) [ 'items' => [] ];
+		}
+
 		/**
 		 * Filter the bulk index path.
 		 * Useful, for example, if a pipeline needs to be added to the bulk index operation.


### PR DESCRIPTION
Add handling for the case in which no posts "should be indexed" within a batch index operation. This PR effectively allows SearchPress to skip making a bulk index request if a complete batch of posts is marked as "should not index". 