### PR TITLE
update grunt packages to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
-
 {
   "name": "searchpress",
   "version": "0.4.0",
   "main": "Gruntfile.js",
   "author": "Matthew Boynes",
   "devDependencies": {
-    "grunt": "~0.4.5",
-    "grunt-wp-i18n": "~0.5.0",
-    "grunt-wp-readme-to-markdown": "~1.0.0"
+    "grunt": "~1.4.1",
+    "grunt-wp-i18n": "~1.0.3",
+    "grunt-wp-readme-to-markdown": "~2.0.1"
   }
 }


### PR DESCRIPTION
# Overview
Appease Dependabot's alerts regarding out of date NPM packages.

## Notes
I tested the output side by side with the current grunt-* packages and found no differences between the updated package versions and the outdated package versions. This was tested with node v12.22.6.