### PR TITLE
Improvements to the CLI commands

### DIFF
--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -1,9 +1,36 @@
 <?php
 
-WP_CLI::add_command( 'searchpress', 'Searchpress_CLI_Command' );
-
 /**
- * CLI Commands for SearchPress
+ * Manage SearchPress through the command-line.
+ *
+ * ## EXAMPLES
+ *
+ *      $ wp searchpress activate
+ *      Successfully activated SearchPress!
+ *
+ *      $ wp searchpress deactivate
+ *      Successfully deactivated SearchPress!
+ *
+ *      $ wp searchpress put-mapping
+ *      Successfully added mapping
+ *
+ *      # Flush the current document index, add the mapping, and index the whole site
+ *      $ wp searchpress index --flush --put-mapping
+ *
+ *      # Index the first 10 posts in the database
+ *      $ wp searchpress index --bulk=10 --limit=10
+ *
+ *      # Index the whole site starting on page 145
+ *      $ wp searchpress index --page=145
+ *
+ *      # Index a single post (post ID 12345)
+ *      $ wp searchpress index 12345
+ *
+ *      # Index six specific posts
+ *      $ wp searchpress index 12340 12341 12342 12343 12344 12345
+ *
+ *      # Index posts published between 11-1-2015 and 12-30-2015 (inclusive)
+ *      $ wp searchpress index --after-date=2015-11-01 --before-date=2015-12-30
  */
 class Searchpress_CLI_Command extends WP_CLI_Command {
 
@@ -15,48 +42,62 @@ class Searchpress_CLI_Command extends WP_CLI_Command {
 	private function contain_memory_leaks() {
 		global $wpdb, $wp_object_cache;
 		$wpdb->queries = array();
-		if ( !is_object( $wp_object_cache ) )
+
+		if ( ! is_object( $wp_object_cache ) ) {
 			return;
+		}
+
 		$wp_object_cache->group_ops = array();
 		$wp_object_cache->stats = array();
 		$wp_object_cache->memcache_debug = array();
 		$wp_object_cache->cache = array();
-		if ( method_exists( $wp_object_cache, '__remoteset' ) )
+		if ( method_exists( $wp_object_cache, '__remoteset' ) ) {
 			$wp_object_cache->__remoteset();
+		}
 	}
-
 
 	/**
 	 * Replacing the site's default search with SearchPress; this should only be done after indexing.
 	 *
+	 * ## EXAMPLE
+	 *
+	 *     $ wp searchpress activate
+	 *     Successfully activated SearchPress!
 	 */
 	public function activate() {
-		WP_CLI::line( "Replacing the default search with SearchPress..." );
+		WP_CLI::log( 'Replacing the default search with SearchPress...' );
 		SP_Config()->update_settings( array( 'active' => true, 'must_init' => false ) );
 		SP_Sync_Meta()->delete();
 		WP_CLI::success( "Successfully activated SearchPress!\n" );
 	}
 
-
 	/**
-	 * Deactivate SearchPress
+	 * Deactivate SearchPress.
 	 *
+	 * ## EXAMPLE
+	 *
+	 *     $ wp searchpress deactivate
+	 *     Successfully deactivated SearchPress!
 	 */
 	public function deactivate() {
-		WP_CLI::line( "Deactivating SearchPress..." );
+		WP_CLI::log( 'Deactivating SearchPress...' );
 		SP_Config()->update_settings( array( 'active' => false, 'must_init' => true ) );
 		SP_Sync_Meta()->delete();
 		WP_CLI::success( "Successfully deactivated SearchPress!\n" );
 	}
 
-
 	/**
-	 * Add the document mapping
+	 * Add the document mapping.
+	 *
+	 * ## EXAMPLE
+	 *
+	 *     $ wp searchpress put-mapping
+	 *     Successfully added mapping
 	 *
 	 * @subcommand put-mapping
 	 */
 	public function put_mapping() {
-		WP_CLI::line( "Adding mapping..." );
+		WP_CLI::log( 'Adding mapping...' );
 		$result = SP_Config()->create_mapping();
 		if ( '200' == SP_API()->last_request['response_code'] ) {
 			WP_CLI::success( "Successfully added mapping\n" );
@@ -67,24 +108,244 @@ class Searchpress_CLI_Command extends WP_CLI_Command {
 		}
 	}
 
-
 	/**
 	 * Flush the current index. !!Warning!! This empties your elasticsearch index for the entire site.
 	 *
+	 * ## EXAMPLE
+	 *
+	 *     $ wp searchpress flush
+	 *     Successfully flushed Post index
 	 */
-	public function flush() {
-		WP_CLI::line( "Flushing current index..." );
+	public function flush( $args = array() ) {
+		WP_CLI::log( 'Flushing current index...' );
 		$result = SP_Config()->flush();
 		if ( '200' == SP_API()->last_request['response_code'] || '404' == SP_API()->last_request['response_code'] ) {
 			WP_CLI::success( "Successfully flushed Post index\n" );
 		} else {
 			print_r( SP_API()->last_request );
 			print_r( $result );
-			WP_CLI::error( "Could not flush existing data!" );
+			WP_CLI::error( 'Could not flush existing data!' );
 		}
 	}
 
- 	/**
+	/**
+	 * Index the current site or individual posts in ElasticSearch, optionally flushing any existing data and adding the document mapping.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--flush]
+	 * : Flushes out the current data.
+	 *
+	 * [--put-mapping]
+	 * : Adds the document mapping in SP_Config().
+	 *
+	 * [--bulk=<num>]
+	 * : Process this many posts as a time. Defaults to 2,000, which seems to
+	 * be the fastest on average.
+	 * ---
+	 * default: 2000
+	 * ---
+	 *
+	 * [--limit=<num>]
+	 * : How many posts to process. Defaults to all posts.
+	 * ---
+	 * default: 0
+	 * ---
+	 *
+	 * [--page=<num>]
+	 * : Which page to start on. This is helpful if you encountered an error on
+	 * page 145/150 or if you want to have multiple processes running at once
+	 * ---
+	 * default: 1
+	 * ---
+	 *
+	 * [--after-date=<date>]
+	 * : Index posts published on or after this date. Use YYYY-MM-DD.
+	 *
+	 * [--before-date=<date>]
+	 * : Index posts published on or before this date. Use YYYY-MM-DD.
+	 *
+	 * [<post-id>...]
+	 * : By default, this subcommand will query posts based on ID and pagination.
+	 * Instead, you can specify one or more individual post IDs to process. Multiple
+	 * post IDs should be space-delimited (see examples)
+	 * If present, the --bulk, --limit, and --page arguments are ignored.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *      # Flush the current document index, add the mapping, and index the whole site
+	 *      $ wp searchpress index --flush --put-mapping
+	 *
+	 *      # Index the first 10 posts in the database
+	 *      $ wp searchpress index --bulk=10 --limit=10
+	 *
+	 *      # Index the whole site starting on page 145
+	 *      $ wp searchpress index --page=145
+	 *
+	 *      # Index a single post (post ID 12345)
+	 *      $ wp searchpress index 12345
+	 *
+	 *      # Index six specific posts
+	 *      $ wp searchpress index 12340 12341 12342 12343 12344 12345
+	 *
+	 *      # Index posts published between 11-1-2015 and 12-30-2015 (inclusive)
+	 *      $ wp searchpress index --after-date=2015-11-01 --before-date=2015-12-30
+	 *
+	 *      # Index posts published after 11-1-2015 (inclusive)
+	 *      $ wp searchpress index --after-date=2015-11-01
+	 *
+	 * @synopsis [--flush] [--put-mapping] [--bulk=<num>] [--limit=<num>] [--page=<num>] [--after-date=<date>] [--before-date=<date>] [<post-id>...]
+	 */
+	public function index( $args, $assoc_args ) {
+		if ( false !== ob_get_length() ) {
+			ob_end_clean();
+		}
+
+		$timestamp_start = microtime( true );
+
+		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'flush' ) ) {
+			$this->flush();
+		}
+
+		if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'put-mapping' ) ) {
+			$this->put_mapping();
+		}
+
+		// Individual post indexing.
+		if ( ! empty( $args ) ) {
+			$num_posts = count( $args );
+			WP_CLI::log( sprintf( _n( 'Indexing %d post', 'Indexing %d posts', $num_posts ), number_format( $num_posts ) ) );
+
+			foreach ( $args as $post_id ) {
+				$post_id = intval( $post_id );
+
+				if ( ! $post_id ) {
+					continue;
+				}
+
+				WP_CLI::log( "Indexing post {$post_id}" );
+				SP_Sync_Manager()->sync_post( $post_id );
+			}
+
+			WP_CLI::success( 'Index complete!' );
+
+		} else {
+
+			// Bulk indexing.
+
+			if ( $assoc_args['limit'] && $assoc_args['limit'] < $assoc_args['bulk'] ) {
+				$assoc_args['bulk'] = $assoc_args['limit'];
+			}
+
+			if ( isset( $assoc_args['after-date'] ) || isset( $assoc_args['before-date'] ) ) {
+				$this->date_range = array();
+				if ( isset( $assoc_args['after-date'] ) ) {
+					$this->date_range['after'] = $assoc_args['after-date'];
+				}
+				if ( isset( $assoc_args['before-date'] ) ) {
+					$this->date_range['before'] = $assoc_args['before-date'];
+				}
+				add_filter( 'searchpress_index_loop_args', array( $this, '__apply_date_range' ) );
+				add_filter( 'searchpress_index_count_args', array( $this, '__apply_date_range' ) );
+			}
+
+			$limit_number = $assoc_args['limit'] > 0 ? $assoc_args['limit'] : SP_Sync_Manager()->count_posts();
+			$limit_text   = sprintf( _n( '%s post', '%s posts', $limit_number ), number_format( $limit_number ) );
+
+			WP_CLI::log(
+				sprintf( 'Indexing %1$s, %2$d at a time, starting on page %3$d', $limit_text, number_format( $assoc_args['bulk'] ), absint( $assoc_args['page'] ) )
+			);
+
+			// Keep tabs on where we are and what we've done.
+			$sync_meta          = SP_Sync_Meta();
+			$sync_meta->page    = intval( $assoc_args['page'] ) - 1;
+			$sync_meta->bulk    = $assoc_args['bulk'];
+			$sync_meta->running = true;
+
+			$total_pages      = $limit_number / $sync_meta->bulk;
+			$total_pages_ceil = ceil( $total_pages );
+			$start_page       = $sync_meta->page;
+
+			do {
+				$lap = microtime( true );
+				SP_Sync_Manager()->do_index_loop();
+
+				if ( 0 < ( $sync_meta->page - $start_page ) ) {
+					$seconds_per_page = ( microtime( true ) - $timestamp_start ) / ( $sync_meta->page - $start_page );
+					WP_CLI::log( "Completed page {$sync_meta->page}/{$total_pages_ceil} (" . number_format( ( microtime( true ) - $lap), 2 ) . 's / ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'M current / ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'M max), ' . $this->time_format( ( $total_pages - $sync_meta->page ) * $seconds_per_page ) . ' remaining' );
+				}
+
+				$this->contain_memory_leaks();
+
+				if ( $assoc_args['limit'] > 0 && $sync_meta->processed >= $assoc_args['limit'] ) {
+					break;
+				}
+			} while ( $sync_meta->page < $total_pages_ceil );
+
+			$errors = ! empty( $sync_meta->messages['error'] ) ? count( $sync_meta->messages['error'] ) : 0;
+			$errors += ! empty( $sync_meta->messages['warning'] ) ? count( $sync_meta->messages['warning'] ) : 0;
+
+			WP_CLI::success( sprintf(
+				__( "Index Complete!\n%d\tposts processed\n%d\tposts indexed\n%d\terrors/warnings", 'searchpress' ),
+				$sync_meta->processed,
+				$sync_meta->success,
+				$errors
+			) );
+
+			$this->activate();
+		}
+
+		$this->finish( $timestamp_start );
+	}
+
+	/**
+	 * Index a single post in ElasticSearch and output debugging information. You should enable `SP_DEBUG` and `SAVEQUERIES` before running this.
+	 *
+	 * <post_id>
+	 * : Post ID to index.
+	 *
+	 * ## EXAMPLE
+	 *
+	 *     $ wp searchpress debug 123
+	 *     Index complete!
+	 */
+	public function debug( $args ) {
+		global $wpdb;
+
+		$post_id = intval( $args[0] );
+
+		if ( empty( $post_id ) ) {
+			WP_CLI::error( 'Invalid post ID.' );
+		}
+
+		if ( ! defined( 'SP_DEBUG') ) {
+			WP_CLI::error( 'SP_DEBUG should be enabled before running this.' );
+		}
+
+		if ( ! defined( 'SAVEQUERIES') ) {
+			WP_CLI::error( 'SAVEQUERIES should be enabled before running this.' );
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! $post instanceof WP_Post || empty( $post->ID ) ) {
+			WP_CLI::error( 'Post does not exist.' );
+		}
+
+		$timestamp_start = microtime( true );
+
+		WP_CLI::log( "Indexing post {$post_id}" );
+
+		SP_Sync_Manager()->sync_post( $post_id );
+
+		WP_CLI::success( 'Index complete!' );
+
+		print_r( $wpdb->queries );
+
+		$this->finish( $timestamp_start );
+	}
+
+	/**
 	 * Add date range when retrieving posts in bulk.
 	 * Dates need to be passed as YYYY-MM-DD. See synopsis for index function.
 	 *
@@ -117,194 +378,13 @@ class Searchpress_CLI_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Index the current site or individual posts in elasticsearch, optionally flushing any existing data and adding the document mapping.
+	 * Finish helper.
 	 *
-	 * ## OPTIONS
-	 *
-	 * [--flush]
-	 * : Flushes out the current data
-	 *
-	 * [--put-mapping]
-	 * : Adds the document mapping in SP_Config()
-	 *
-	 * [--bulk=<num>]
-	 * : Process this many posts as a time. Defaults to 2,000, which seems to
-	 * be the fastest on average.
-	 *
-	 * [--limit=<num>]
-	 * : How many posts to process. Defaults to all posts.
-	 *
-	 * [--page=<num>]
-	 * : Which page to start on. This is helpful if you encountered an error on
-	 * page 145/150 or if you want to have multiple processes running at once
-	 *
-	 * [--after-date=<date>]
-	 * : Index posts published on or after this date. Use YYYY-MM-DD.
-	 *
-	 * [--before-date=<date>]
-	 * : Index posts published on or before this date. Use YYYY-MM-DD.
-	 *
-	 * [<post-id>...]
-	 * : By default, this subcommand will query posts based on ID and pagination.
-	 * Instead, you can specify one or more individual post IDs to process. Multiple
-	 * post IDs should be space-delimited (see examples)
-	 * If present, the --bulk, --limit, and --page arguments are ignored.
-	 *
-	 * ## EXAMPLES
-	 *
-	 *      # Flush the current document index, add the mapping, and index the whole site
-	 *      wp searchpress index --flush --put-mapping
-	 *
-	 *      # Index the first 10 posts in the database
-	 *      wp searchpress index --bulk=10 --limit=10
-	 *
-	 *      # Index the whole site starting on page 145
-	 *      wp searchpress index --page=145
-	 *
-	 *      # Index a single post (post ID 12345)
-	 *      wp searchpress index 12345
-	 *
-	 *      # Index six specific posts
-	 *      wp searchpress index 12340 12341 12342 12343 12344 12345
-	 *
-	 *      # Index posts published between 11-1-2015 and 12-30-2015 (inclusive)
-	 *      wp searchpress index --after-date=2015-11-01 --before-date=2015-12-30
-	 *
-	 *      # Index posts published after 11-1-2015 (inclusive)
-	 *      wp searchpress index --after-date=2015-11-01
-	 *
-	 * @synopsis [--flush] [--put-mapping] [--bulk=<num>] [--limit=<num>] [--page=<num>] [--after-date=<date>] [--before-date=<date>] [<post-id>...]
+	 * @param int $timestamp_start Start timestamp.
 	 */
-	public function index( $args, $assoc_args ) {
-		if ( false !== ob_get_length() ) {
-			ob_end_clean();
-		}
-
-		$timestamp_start = microtime( true );
-
-		if ( ! empty( $assoc_args['flush'] ) ) {
-			$this->flush();
-		}
-
-		if ( ! empty( $assoc_args['put-mapping'] ) ) {
-			$this->put_mapping();
-		}
-
-		if ( ! empty( $args ) ) {
-			// Individual post indexing
-			$num_posts = count( $args );
-			WP_CLI::line( sprintf( _n( "Indexing %d post", "Indexing %d posts", $num_posts ), $num_posts ) );
-
-			foreach ( $args as $post_id ) {
-				$post_id = intval( $post_id );
-				if ( ! $post_id )
-					continue;
-
-				WP_CLI::line( "Indexing post {$post_id}" );
-				SP_Sync_Manager()->sync_post( $post_id );
-			}
-			WP_CLI::success( "Index complete!" );
-
-		} else {
-			// Bulk indexing
-
-			$assoc_args = array_merge( array(
-				'bulk'  => 2000,
-				'limit' => 0,
-				'page'  => 1
-			), $assoc_args );
-
-			if ( $assoc_args['limit'] && $assoc_args['limit'] < $assoc_args['bulk'] ) {
-				$assoc_args['bulk'] = $assoc_args['limit'];
-			}
-
-			if ( isset( $assoc_args['after-date'] ) || isset( $assoc_args['before-date'] ) ) {
-				$this->date_range = array();
-				if ( isset( $assoc_args['after-date'] ) ) {
-					$this->date_range['after'] = $assoc_args['after-date'];
-				}
-				if ( isset( $assoc_args['before-date'] ) ) {
-					$this->date_range['before'] = $assoc_args['before-date'];
-				}
-				add_filter( 'searchpress_index_loop_args', array( $this, '__apply_date_range' ) );
-				add_filter( 'searchpress_index_count_args', array( $this, '__apply_date_range' ) );
-			}
-
-			$limit_number = $assoc_args['limit'] > 0 ? $assoc_args['limit'] : SP_Sync_Manager()->count_posts();
-			$limit_text = sprintf( _n( '%s post', '%s posts', $limit_number ), number_format( $limit_number ) );
-			WP_CLI::line( "Indexing {$limit_text}, " . number_format( $assoc_args['bulk'] ) . " at a time, starting on page {$assoc_args['page']}" );
-
-			// Keep tabs on where we are and what we've done
-			$sync_meta = SP_Sync_Meta();
-			$sync_meta->page = intval( $assoc_args['page'] ) - 1;
-			$sync_meta->bulk = $assoc_args['bulk'];
-			$sync_meta->running = true;
-
-			$total_pages = $limit_number / $sync_meta->bulk;
-			$total_pages_ceil = ceil( $total_pages );
-			$start_page = $sync_meta->page;
-
-			do {
-				$lap = microtime( true );
-				SP_Sync_Manager()->do_index_loop();
-
-				if ( 0 < ( $sync_meta->page - $start_page ) ) {
-					$seconds_per_page = ( microtime( true ) - $timestamp_start ) / ( $sync_meta->page - $start_page );
-					WP_CLI::line( "Completed page {$sync_meta->page}/{$total_pages_ceil} (" . number_format( ( microtime( true ) - $lap), 2 ) . 's / ' . round( memory_get_usage() / 1024 / 1024, 2 ) . 'M current / ' . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . 'M max), ' . $this->time_format( ( $total_pages - $sync_meta->page ) * $seconds_per_page ) . ' remaining' );
-				}
-
-				$this->contain_memory_leaks();
-
-				if ( $assoc_args['limit'] > 0 && $sync_meta->processed >= $assoc_args['limit'] ) {
-					break;
-				}
-			} while ( $sync_meta->page < $total_pages_ceil );
-
-			$errors = ! empty( $sync_meta->messages['error'] ) ? count( $sync_meta->messages['error'] ) : 0;
-			$errors += ! empty( $sync_meta->messages['warning'] ) ? count( $sync_meta->messages['warning'] ) : 0;
-
-			WP_CLI::success( sprintf(
-				__( "Index Complete!\n%d\tposts processed\n%d\tposts indexed\n%d\terrors/warnings", 'searchpress' ),
-				$sync_meta->processed,
-				$sync_meta->success,
-				$errors
-			) );
-
-			$this->activate();
-		}
-
-		$this->finish( $timestamp_start );
-	}
-
-
-	/**
-	 * Index a single post in elasticsearch and output debugging information. You should enable SP_DEBUG and SAVEQUERIES before running this.
-	 *
-	 * @synopsis <post_id>
-	 */
-	public function debug( $args ) {
-		if ( empty( $args[0] ) )
-			WP_CLI::error( "Invalid post ID" );
-		$post_id = intval( $args[0] );
-		if ( ! $post_id )
-			WP_CLI::error( "Invalid post ID" );
-
-		global $wpdb;
-		$timestamp_start = microtime( true );
-
-		WP_CLI::line( "Indexing post {$post_id}" );
-
-		SP_Sync_Manager()->sync_post( $post_id );
-
-		WP_CLI::success( "Index complete!" );
-		print_r( $wpdb->queries );
-
-		$this->finish( $timestamp_start );
-	}
-
 	private function finish( $timestamp_start ) {
-		WP_CLI::line( "Process completed in " . $this->time_format( microtime( true ) - $timestamp_start ) );
-		WP_CLI::line( "Max memory usage was " . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . "M" );
+		WP_CLI::log( "Process completed in " . $this->time_format( microtime( true ) - $timestamp_start ) );
+		WP_CLI::log( "Max memory usage was " . round( memory_get_peak_usage() / 1024 / 1024, 2 ) . "M" );
 	}
 
 	private function time_format( $seconds ) {
@@ -326,5 +406,6 @@ class Searchpress_CLI_Command extends WP_CLI_Command {
 		}
 		return $ret . absint( ceil( $seconds ) ) . 's';
 	}
-
 }
+
+WP_CLI::add_command( 'searchpress', 'Searchpress_CLI_Command' );

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -319,11 +319,11 @@ class Searchpress_CLI_Command extends WP_CLI_Command {
 		}
 
 		if ( ! defined( 'SP_DEBUG') ) {
-			WP_CLI::error( 'SP_DEBUG should be enabled before running this.' );
+			WP_CLI::warning( 'SP_DEBUG should be enabled before running this.' );
 		}
 
 		if ( ! defined( 'SAVEQUERIES') ) {
-			WP_CLI::error( 'SAVEQUERIES should be enabled before running this.' );
+			WP_CLI::warning( 'SAVEQUERIES should be enabled before running this.' );
 		}
 
 		$post = get_post( $post_id );

--- a/bin/wp-cli.php
+++ b/bin/wp-cli.php
@@ -116,7 +116,7 @@ class Searchpress_CLI_Command extends WP_CLI_Command {
 	 *     $ wp searchpress flush
 	 *     Successfully flushed Post index
 	 */
-	public function flush( $args = array() ) {
+	public function flush() {
 		WP_CLI::log( 'Flushing current index...' );
 		$result = SP_Config()->flush();
 		if ( '200' == SP_API()->last_request['response_code'] || '404' == SP_API()->last_request['response_code'] ) {


### PR DESCRIPTION
- Improving PHPDoc
- More CLI command examples
- Adding more standards from https://make.wordpress.org/cli/handbook/guides/commands-cookbook/
- Using `WP_CLI::log` instead of `WP_CLI::line`
- The `debug` command checks for the existence of a valid post and adds a warning for `SP_DEBUG` and `SAVEQUERIES`
- Use `WP_CLI\Utils\get_flag_value` to get flag values
- Use quote instead of double quotes