### PR TITLE
Adjust empty-string search integrations

### DIFF
--- a/lib/class-sp-integration.php
+++ b/lib/class-sp-integration.php
@@ -108,7 +108,17 @@ class SP_Integration extends SP_Singleton {
 	 * @return array|null
 	 */
 	public function filter__posts_pre_query( $posts, $query ) {
-		if ( ! $query->is_main_query() || ! $query->is_search() ) {
+		$should_auto_integrate = $query->is_main_query() && $query->is_search();
+		if (
+			/**
+			 * Should a query be automatically integrated with SearchPress?
+			 *
+			 * @param bool     $should_auto_integrate Whether the query should be auto-integrated with SearchPress. This
+			 * 									      defaults to true if the query is the main search query.
+			 * @param WP_Query $query                 The query object.
+			 */
+			! apply_filters( 'sp_integrate_query', $should_auto_integrate, $query )
+		) {
 			return $posts;
 		}
 
@@ -116,6 +126,9 @@ class SP_Integration extends SP_Singleton {
 		if ( '1441f19754335ca4638bfdf1aea00c6d' === $query->get( 's' ) ) {
 			$query->set( 's', '' );
 		}
+
+		// Force the query to advertise as a search query.
+		$query->is_search = true;
 
 		$es_wp_query_args = $this->build_es_request( $query );
 

--- a/lib/class-sp-integration.php
+++ b/lib/class-sp-integration.php
@@ -114,7 +114,7 @@ class SP_Integration extends SP_Singleton {
 			 * Filters whether a query should automatically be integrated with SearchPress.
 			 *
 			 * @param bool     $should_auto_integrate Whether the query should be auto-integrated with SearchPress. This
-			 * 									      defaults to true if the query is the main search query.
+			 *                                        defaults to true if the query is the main search query.
 			 * @param WP_Query $query                 The query object.
 			 */
 			! apply_filters( 'sp_integrate_query', $should_auto_integrate, $query )

--- a/lib/class-sp-integration.php
+++ b/lib/class-sp-integration.php
@@ -112,6 +112,11 @@ class SP_Integration extends SP_Singleton {
 			return $posts;
 		}
 
+		// If we put in a phony search term, remove it now.
+		if ( '1441f19754335ca4638bfdf1aea00c6d' === $query->get( 's' ) ) {
+			$query->set( 's', '' );
+		}
+
 		$es_wp_query_args = $this->build_es_request( $query );
 
 		// Convert the WP-style args into ES args.

--- a/lib/class-sp-integration.php
+++ b/lib/class-sp-integration.php
@@ -111,7 +111,7 @@ class SP_Integration extends SP_Singleton {
 		$should_auto_integrate = $query->is_main_query() && $query->is_search();
 		if (
 			/**
-			 * Should a query be automatically integrated with SearchPress?
+			 * Filters whether a query should automatically be integrated with SearchPress.
 			 *
 			 * @param bool     $should_auto_integrate Whether the query should be auto-integrated with SearchPress. This
 			 * 									      defaults to true if the query is the main search query.


### PR DESCRIPTION
* Fixes a regression with forced empty searches (unsets the temp search string)
* Adds a filter to be able to override the integration