### PR TITLE
Add support for ES 8.x

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,12 +10,12 @@ jobs:
       fail-fast: false # do not fail fast, let all the failing tests fail.
       matrix:
         php: [8.0]
-        es_version: [7.17.5]
+        es_version: [7.17.5, 8.10.2]
         multisite: [0]
         wp_version: ["latest"]
         include:
           - php: '7.4'
-            es_version: '7.17.5'
+            es_version: '8.10.2'
             multisite: 0
             wp_version: '5.9.3'
           - php: '7.4'

--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -288,7 +288,7 @@ class SP_API extends SP_Singleton {
 		 * @param SP_Post $post            SP Post Object.
 		 */
 		$post_index_path = apply_filters( 'sp_post_index_path', $this->get_api_endpoint( '_doc', $post->post_id ), $post );
-		return $this->post( $post_index_path, $json );
+		return $this->put( $post_index_path, $json );
 	}
 
 	/**

--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -95,15 +95,41 @@ class SP_API extends SP_Singleton {
 	public function get_doc_type() {
 		if ( empty( $this->doc_type ) ) {
 			if ( sp_es_version_compare( '6.0', '<' ) ) {
-				$this->doc_type = 'post/';
-			} elseif ( sp_es_version_compare( '8.0', '<' ) ) {
-				$this->doc_type = '_doc/';
+				$this->doc_type = 'post';
 			} else {
-				$this->doc_type = '';
+				$this->doc_type = '_doc';
 			}
 		}
 
 		return $this->doc_type;
+	}
+
+	/**
+	 * Get the API endpoint for a given API and resource.
+	 *
+	 * This function helps work around version changes in Elasticsearch's API
+	 * endpoints. For example, in ES 8.0, the `_doc` endpoint was removed from
+	 * some API endpoints.
+	 *
+	 * @param string|null     $api      API type.
+	 * @param string|int|null $resource Resource ID.
+	 * @return string|null API endpoint.
+	 */
+	public function get_api_endpoint( $api = null, $resource = null ) {
+		// Endpoints that vary doc type, and if it's included, based on ES version.
+		if ( in_array( $api, [ '_search', '_bulk', '_count' ], true ) ) {
+			if ( sp_es_version_compare( '8.0' ) ) {
+				return $api;
+			}
+			return $this->get_doc_type() . '/' . $api;
+		}
+
+		// Doc endpoint.
+		if ( '_doc' === $api ) {
+			return $this->get_doc_type() . ( $resource ? '/' . $resource : '' );
+		}
+
+		return $api;
 	}
 
 	/**
@@ -261,8 +287,8 @@ class SP_API extends SP_Singleton {
 		 * @param string  $post_index_path Single post index path.
 		 * @param SP_Post $post            SP Post Object.
 		 */
-		$post_index_path = apply_filters( 'sp_post_index_path', "{$this->get_doc_type()}{$post->post_id}", $post );
-		return $this->put( $post_index_path, $json );
+		$post_index_path = apply_filters( 'sp_post_index_path', $this->get_api_endpoint( '_doc', $post->post_id ), $post );
+		return $this->post( $post_index_path, $json );
 	}
 
 	/**
@@ -304,7 +330,7 @@ class SP_API extends SP_Singleton {
 		 *
 		 * @param string $bulk_index_path Bulk index path.
 		 */
-		$bulk_index_path = apply_filters( 'sp_bulk_index_path', "{$this->get_doc_type()}_bulk" );
+		$bulk_index_path = apply_filters( 'sp_bulk_index_path', $this->get_api_endpoint( '_bulk' ) );
 		return $this->put(
 			$bulk_index_path,
 			wp_check_invalid_utf8( implode( "\n", $body ), true ) . "\n"
@@ -318,7 +344,7 @@ class SP_API extends SP_Singleton {
 	 * @return object The response from the API.
 	 */
 	public function delete_post( $post_id ) {
-		return $this->delete( "{$this->get_doc_type()}{$post_id}" );
+		return $this->delete( $this->get_api_endpoint( '_doc', $post_id ) );
 	}
 
 	/**
@@ -336,7 +362,7 @@ class SP_API extends SP_Singleton {
 				'output' => OBJECT,
 			)
 		);
-		return $this->post( "{$this->get_doc_type()}_search", $query, $args['output'] );
+		return $this->post( $this->get_api_endpoint( '_search' ), $query, $args['output'] );
 	}
 
 	/**

--- a/lib/class-sp-api.php
+++ b/lib/class-sp-api.php
@@ -95,9 +95,11 @@ class SP_API extends SP_Singleton {
 	public function get_doc_type() {
 		if ( empty( $this->doc_type ) ) {
 			if ( sp_es_version_compare( '6.0', '<' ) ) {
-				$this->doc_type = 'post';
+				$this->doc_type = 'post/';
+			} elseif ( sp_es_version_compare( '8.0', '<' ) ) {
+				$this->doc_type = '_doc/';
 			} else {
-				$this->doc_type = '_doc';
+				$this->doc_type = '';
 			}
 		}
 
@@ -259,7 +261,7 @@ class SP_API extends SP_Singleton {
 		 * @param string  $post_index_path Single post index path.
 		 * @param SP_Post $post            SP Post Object.
 		 */
-		$post_index_path = apply_filters( 'sp_post_index_path', "{$this->get_doc_type()}/{$post->post_id}", $post );
+		$post_index_path = apply_filters( 'sp_post_index_path', "{$this->get_doc_type()}{$post->post_id}", $post );
 		return $this->put( $post_index_path, $json );
 	}
 
@@ -302,7 +304,7 @@ class SP_API extends SP_Singleton {
 		 *
 		 * @param string $bulk_index_path Bulk index path.
 		 */
-		$bulk_index_path = apply_filters( 'sp_bulk_index_path', "{$this->get_doc_type()}/_bulk" );
+		$bulk_index_path = apply_filters( 'sp_bulk_index_path', "{$this->get_doc_type()}_bulk" );
 		return $this->put(
 			$bulk_index_path,
 			wp_check_invalid_utf8( implode( "\n", $body ), true ) . "\n"
@@ -316,7 +318,7 @@ class SP_API extends SP_Singleton {
 	 * @return object The response from the API.
 	 */
 	public function delete_post( $post_id ) {
-		return $this->delete( "{$this->get_doc_type()}/{$post_id}" );
+		return $this->delete( "{$this->get_doc_type()}{$post_id}" );
 	}
 
 	/**
@@ -334,7 +336,7 @@ class SP_API extends SP_Singleton {
 				'output' => OBJECT,
 			)
 		);
-		return $this->post( "{$this->get_doc_type()}/_search", $query, $args['output'] );
+		return $this->post( "{$this->get_doc_type()}_search", $query, $args['output'] );
 	}
 
 	/**

--- a/lib/class-sp-sync-manager.php
+++ b/lib/class-sp-sync-manager.php
@@ -295,7 +295,7 @@ class SP_Sync_Manager extends SP_Singleton {
 	 * @return int
 	 */
 	public function count_posts_indexed() {
-		$count = SP_API()->get( SP_API()->get_doc_type() . '/_count' );
+		$count = SP_API()->get( SP_API()->get_doc_type() . '_count' );
 		return ! empty( $count->count ) ? intval( $count->count ) : 0;
 	}
 }

--- a/lib/class-sp-sync-manager.php
+++ b/lib/class-sp-sync-manager.php
@@ -295,7 +295,7 @@ class SP_Sync_Manager extends SP_Singleton {
 	 * @return int
 	 */
 	public function count_posts_indexed() {
-		$count = SP_API()->get( SP_API()->get_doc_type() . '_count' );
+		$count = SP_API()->get( SP_API()->get_api_endpoint( '_count' ) );
 		return ! empty( $count->count ) ? intval( $count->count ) : 0;
 	}
 }

--- a/lib/class-sp-wp-search.php
+++ b/lib/class-sp-wp-search.php
@@ -332,10 +332,11 @@ class SP_WP_Search extends SP_Search {
 						break;
 
 					case 'date_histogram':
+						$interval_param = sp_es_version_compare( '7.0' ) ? 'calendar_interval' : 'interval';
 						$es_query_args['aggregations'][ $label ] = array(
 							'date_histogram' => array(
-								'interval' => $facet['interval'],
-								'field'    => ! empty( $facet['field'] ) ? "{$facet['field']}.date" : 'post_date.date',
+								$interval_param => $facet['interval'],
+								'field'         => ! empty( $facet['field'] ) ? "{$facet['field']}.date" : 'post_date.date',
 							),
 						);
 

--- a/lib/class-sp-wp-search.php
+++ b/lib/class-sp-wp-search.php
@@ -333,6 +333,7 @@ class SP_WP_Search extends SP_Search {
 
 					case 'date_histogram':
 						$interval_param = sp_es_version_compare( '7.0' ) ? 'calendar_interval' : 'interval';
+
 						$es_query_args['aggregations'][ $label ] = array(
 							'date_histogram' => array(
 								$interval_param => $facet['interval'],

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -14,45 +14,45 @@ class Tests_Api extends SearchPress_UnitTestCase {
 	}
 
 	function test_api_get() {
-		$response = SP_API()->get( SP_API()->get_doc_type() . self::$post_id );
+		$response = SP_API()->get( SP_API()->get_api_endpoint( '_doc', self::$post_id ) );
 		$this->assertEquals( 'GET', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '200', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 		$this->assertEquals( self::$post_id, $response->_source->post_id );
 
-		SP_API()->get( SP_API()->get_doc_type() . "foo" );
+		SP_API()->get( SP_API()->get_api_endpoint( '_doc', 'foo' ) );
 		$this->assertEquals( 'GET', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '404', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 	}
 
 	function test_api_post() {
-		$response = SP_API()->post( SP_API()->get_doc_type() . '_search', '{"query":{"match_all":{}}}' );
+		$response = SP_API()->post( SP_API()->get_api_endpoint( '_search' ), '{"query":{"match_all":{}}}' );
 		$this->assertEquals( 'POST', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '200', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 		$this->assertEquals( self::$post_id, $response->hits->hits[0]->_source->post_id );
 	}
 
 	function test_api_put() {
-		SP_API()->get( SP_API()->get_doc_type() . '123456' );
+		SP_API()->get( SP_API()->get_api_endpoint( '_doc', '123456' ) );
 		$this->assertEquals( '404', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 
-		SP_API()->put( SP_API()->get_doc_type() . '123456', '{"post_id":123456}' );
+		SP_API()->put( SP_API()->get_api_endpoint( '_doc', '123456' ), '{"post_id":123456}' );
 		$this->assertEquals( 'PUT', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '201', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 
-		$response = SP_API()->get( SP_API()->get_doc_type() . '123456' );
+		$response = SP_API()->get( SP_API()->get_api_endpoint( '_doc', '123456' ) );
 		$this->assertEquals( 123456, $response->_source->post_id );
 	}
 
 	function test_api_delete() {
-		SP_API()->put( SP_API()->get_doc_type() . '223456', '{"post_id":223456}' );
+		SP_API()->put( SP_API()->get_api_endpoint( '_doc', '223456' ), '{"post_id":223456}' );
 		$this->assertEquals( '201', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
-		$response = SP_API()->get( SP_API()->get_doc_type() . "223456" );
+		$response = SP_API()->get( SP_API()->get_api_endpoint( '_doc', '223456' ) );
 		$this->assertEquals( 223456, $response->_source->post_id );
 
-		SP_API()->delete( SP_API()->get_doc_type() . '223456' );
+		SP_API()->delete( SP_API()->get_api_endpoint( '_doc', '223456' ) );
 		$this->assertEquals( '200', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 
-		SP_API()->delete( SP_API()->get_doc_type() . '223456' );
+		SP_API()->delete( SP_API()->get_api_endpoint( '_doc', '223456' ) );
 		$this->assertEquals( '404', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 	}
 
@@ -84,7 +84,7 @@ class Tests_Api extends SearchPress_UnitTestCase {
 			};
 		} );
 
-        SP_API()->put( SP_API()->get_doc_type() . '123456', '{"post_id":123456}' );
+        SP_API()->put( SP_API()->get_api_endpoint( '_doc', '123456' ), '{"post_id":123456}' );
 
 		$this->assertSame( 'PUT', $method );
 		$this->assertSame( 'before request', $pre );

--- a/tests/test-api.php
+++ b/tests/test-api.php
@@ -14,45 +14,45 @@ class Tests_Api extends SearchPress_UnitTestCase {
 	}
 
 	function test_api_get() {
-		$response = SP_API()->get( SP_API()->get_doc_type() . '/' . self::$post_id );
+		$response = SP_API()->get( SP_API()->get_doc_type() . self::$post_id );
 		$this->assertEquals( 'GET', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '200', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 		$this->assertEquals( self::$post_id, $response->_source->post_id );
 
-		SP_API()->get( SP_API()->get_doc_type() . "/foo" );
+		SP_API()->get( SP_API()->get_doc_type() . "foo" );
 		$this->assertEquals( 'GET', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '404', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 	}
 
 	function test_api_post() {
-		$response = SP_API()->post( SP_API()->get_doc_type() . '/_search', '{"query":{"match_all":{}}}' );
+		$response = SP_API()->post( SP_API()->get_doc_type() . '_search', '{"query":{"match_all":{}}}' );
 		$this->assertEquals( 'POST', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '200', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 		$this->assertEquals( self::$post_id, $response->hits->hits[0]->_source->post_id );
 	}
 
 	function test_api_put() {
-		SP_API()->get( SP_API()->get_doc_type() . '/123456' );
+		SP_API()->get( SP_API()->get_doc_type() . '123456' );
 		$this->assertEquals( '404', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 
-		SP_API()->put( SP_API()->get_doc_type() . '/123456', '{"post_id":123456}' );
+		SP_API()->put( SP_API()->get_doc_type() . '123456', '{"post_id":123456}' );
 		$this->assertEquals( 'PUT', SP_API()->last_request['params']['method'] );
 		$this->assertEquals( '201', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 
-		$response = SP_API()->get( SP_API()->get_doc_type() . '/123456' );
+		$response = SP_API()->get( SP_API()->get_doc_type() . '123456' );
 		$this->assertEquals( 123456, $response->_source->post_id );
 	}
 
 	function test_api_delete() {
-		SP_API()->put( SP_API()->get_doc_type() . '/223456', '{"post_id":223456}' );
+		SP_API()->put( SP_API()->get_doc_type() . '223456', '{"post_id":223456}' );
 		$this->assertEquals( '201', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
-		$response = SP_API()->get( SP_API()->get_doc_type() . "/223456" );
+		$response = SP_API()->get( SP_API()->get_doc_type() . "223456" );
 		$this->assertEquals( 223456, $response->_source->post_id );
 
-		SP_API()->delete( SP_API()->get_doc_type() . '/223456' );
+		SP_API()->delete( SP_API()->get_doc_type() . '223456' );
 		$this->assertEquals( '200', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 
-		SP_API()->delete( SP_API()->get_doc_type() . '/223456' );
+		SP_API()->delete( SP_API()->get_doc_type() . '223456' );
 		$this->assertEquals( '404', wp_remote_retrieve_response_code( SP_API()->last_request['response'] ) );
 	}
 
@@ -84,7 +84,7 @@ class Tests_Api extends SearchPress_UnitTestCase {
 			};
 		} );
 
-        SP_API()->put( SP_API()->get_doc_type() . '/123456', '{"post_id":123456}' );
+        SP_API()->put( SP_API()->get_doc_type() . '123456', '{"post_id":123456}' );
 
 		$this->assertSame( 'PUT', $method );
 		$this->assertSame( 'before request', $pre );


### PR DESCRIPTION
ES 8.0 introduced [a number of breaking changes](https://www.elastic.co/guide/en/elastic-stack/8.0/elasticsearch-breaking-changes.html). Those that directly impacted SearchPress were:

- [REST API endpoint changes](https://www.elastic.co/guide/en/elastic-stack/8.0/elasticsearch-breaking-changes.html#_rest_api_changes); specifically, `_doc/` was removed from several API endpoints, like `_bulk`, `_count`, and `_search`.
- [The date_histogram aggregation’s interval parameter is no longer valid](https://www.elastic.co/guide/en/elastic-stack/8.0/elasticsearch-breaking-changes.html#date-histogram-interval), and needed to be replaced with `calendar_interval`.