### PR TITLE
fix possible fatal where ->sp is set but is not an array

### DIFF
--- a/lib/class-sp-integration.php
+++ b/lib/class-sp-integration.php
@@ -176,7 +176,7 @@ class SP_Integration extends SP_Singleton {
 		$this->sp = get_query_var( 'sp' );
 
 		// If this is a search, but not a keyword search, we have to fake it.
-		if ( ! $wp_query->is_search() && ! empty( $this->sp ) && 1 === intval( $this->sp['force'] ) ) {
+		if ( ! $wp_query->is_search() && isset( $this->sp['force'] ) && 1 === intval( $this->sp['force'] ) ) {
 			// First, we'll set the search string to something phony.
 			$wp_query->set( 's', '1441f19754335ca4638bfdf1aea00c6d' );
 			$wp_query->is_search = true;


### PR DESCRIPTION
We have encountered a few cases in which `get_query_var( 'sp' )` returns a string, instead of an array. This causes a fatal on line 144 below (line 179 on the nyp modified version):

```
PHP Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /var/www/wp-content/plugins/searchpress/lib/class-sp-integration.php:179 
```

Replacing the `empty` check for `isset` will make sure we guard against that scenario.

Fixes [NYP-19074]

[NYP-19074]: https://alleyinteractive.atlassian.net/browse/NYP-19074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ