### PR TITLE
Refactor heartbeat to also record last query time

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Set up WordPress
         run: |
+          sudo apt-get install -y subversion
           bash <(curl -s "https://raw.githubusercontent.com/wp-cli/sample-plugin/master/bin/install-wp-tests.sh") wordpress_test root '' 127.0.0.1 ${{ matrix.wp_version }}
           rm -rf "${WP_CORE_DIR}wp-content/plugins"
           mkdir -p "${WP_CORE_DIR}wp-content/plugins/searchpress"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Set up WordPress
         run: |
-          sudo apt-get install -y subversion
+          sudo apt-get update && sudo apt-get install subversion
           bash <(curl -s "https://raw.githubusercontent.com/wp-cli/sample-plugin/master/bin/install-wp-tests.sh") wordpress_test root '' 127.0.0.1 ${{ matrix.wp_version }}
           rm -rf "${WP_CORE_DIR}wp-content/plugins"
           mkdir -p "${WP_CORE_DIR}wp-content/plugins/searchpress"

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Changelog
 ### 0.5.2
 
 * **POSSIBLE BREAKING CHANGE** Refactors `SP_Heartbeat` to store the last time the beat was checked as well as the last time the beat was verified. `SP_Heartbeat::get_last_beat()` previously returned an int, but now returns an array.
-* Assorted improvements for IDE static analysis.
+* Includes assorted improvements for IDE static analysis.
 
 ### 0.5.1
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ add_filter(
 Changelog
 ---------
 
+### 0.5.2
+
+* **POSSIBLE BREAKING CHANGE** Refactors `SP_Heartbeat` to store the last time the beat was checked as well as the last time the beat was verified. `SP_Heartbeat::get_last_beat()` previously returned an int, but now returns an array.
+* Assorted improvements for IDE static analysis.
+
 ### 0.5.1
 
 * Adds `sp_api_request_url` filter to filter the API url.

--- a/lib/class-sp-admin.php
+++ b/lib/class-sp-admin.php
@@ -46,15 +46,19 @@ class SP_Admin extends SP_Singleton {
 		$this->allow_flushing = ! apply_filters( 'sp_disable_flush_via_ui', false );
 
 		if ( current_user_can( $this->capability ) ) {
-			add_action( 'admin_menu', array( $this, 'admin_menu' ) );
-			add_action( 'admin_post_sp_full_sync', array( $this, 'full_sync' ) );
-			add_action( 'admin_post_sp_cancel_sync', array( $this, 'cancel_sync' ) );
-			add_action( 'admin_post_sp_settings', array( $this, 'save_settings' ) );
-			add_action( 'admin_post_sp_clear_log', array( $this, 'clear_log' ) );
-			add_action( 'admin_post_sp_active_toggle', array( $this, 'active_toggle' ) );
-			add_action( 'wp_ajax_sp_sync_status', array( $this, 'sp_sync_status' ) );
-			add_action( 'admin_notices', array( $this, 'admin_notices' ) );
-			add_action( 'admin_enqueue_scripts', array( $this, 'assets' ) );
+			if ( SP_Heartbeat()->get_status() === 'stale' ) {
+				// If the heartbeat is stale, update it.
+				add_action( 'admin_init', [ SP_Heartbeat(), 'check_beat' ] );
+			}
+			add_action( 'admin_menu', [ $this, 'admin_menu' ] );
+			add_action( 'admin_post_sp_full_sync', [ $this, 'full_sync' ] );
+			add_action( 'admin_post_sp_cancel_sync', [ $this, 'cancel_sync' ] );
+			add_action( 'admin_post_sp_settings', [ $this, 'save_settings' ] );
+			add_action( 'admin_post_sp_clear_log', [ $this, 'clear_log' ] );
+			add_action( 'admin_post_sp_active_toggle', [ $this, 'active_toggle' ] );
+			add_action( 'wp_ajax_sp_sync_status', [ $this, 'sp_sync_status' ] );
+			add_action( 'admin_notices', [ $this, 'admin_notices' ] );
+			add_action( 'admin_enqueue_scripts', [ $this, 'assets' ] );
 		}
 	}
 

--- a/lib/class-sp-admin.php
+++ b/lib/class-sp-admin.php
@@ -426,7 +426,7 @@ class SP_Admin extends SP_Singleton {
 					return array(
 						__( 'OK', 'searchpress' ),
 						// translators: amount of time since last heartbeat (e.g., 36 minutes).
-						sprintf( __( 'SearchPress is active and the Elasticsearch server was last seen %s ago.', 'searchpress' ), human_time_diff( SP_Heartbeat()->get_last_beat(), time() ) ),
+						sprintf( __( 'SearchPress is active and the Elasticsearch server was last seen %s ago.', 'searchpress' ), human_time_diff( SP_Heartbeat()->last_seen(), time() ) ),
 					);
 				case 'alert':
 					return array(
@@ -746,7 +746,7 @@ class SP_Admin extends SP_Singleton {
 		}
 
 		$heartbeat_status = SP_Heartbeat()->get_status();
-		if ( 'ok' !== $heartbeat_status ) {
+		if ( 'ok' !== $heartbeat_status && 'stale' !== $heartbeat_status ) {
 			$message_escaped = esc_html__( 'SearchPress cannot reach the Elasticsearch server!', 'searchpress' );
 			if ( 'never' === $heartbeat_status && ! $this->is_settings_page() ) {
 				$message_escaped .= sprintf(
@@ -756,7 +756,7 @@ class SP_Admin extends SP_Singleton {
 				);
 			} elseif ( 'never' !== $heartbeat_status ) {
 				// translators: amount of time with units (e.g., 36 minutes).
-				$message_escaped .= ' ' . sprintf( esc_html__( 'The Elasticsearch server was last seen %s ago.', 'searchpress' ), human_time_diff( SP_Heartbeat()->get_last_beat(), time() ) );
+				$message_escaped .= ' ' . sprintf( esc_html__( 'The Elasticsearch server was last seen %s ago.', 'searchpress' ), human_time_diff( SP_Heartbeat()->last_seen(), time() ) );
 			}
 			if ( 'shutdown' === $heartbeat_status ) {
 				$message_escaped .= "\n" . esc_html__( "SearchPress has deactivated itself to preserve site search for your visitors. Your site will use WordPress' built-in search until the Elasticsearch server comes back online.", 'searchpress' );

--- a/lib/class-sp-config.php
+++ b/lib/class-sp-config.php
@@ -6,7 +6,17 @@
  */
 
 /**
- * SearchPress configuration
+ * SearchPress configuration.
+ *
+ * @method string     host()        Host setting value.
+ * @method bool       must_init()   If SP needs to be initialized.
+ * @method bool       active()      If SP is active.
+ * @method int        map_version() Stored mapping version.
+ * @method int|string es_version()  Stored ES version.
+ * @method string     username()    Auth username.
+ * @method string     basic_auth()  Hashed basic auth info.
+ * @method string     index()       ES index name.
+ * @method string     auth_header() Authentication header.
  */
 class SP_Config extends SP_Singleton {
 

--- a/lib/class-sp-heartbeat.php
+++ b/lib/class-sp-heartbeat.php
@@ -72,8 +72,8 @@ class SP_Heartbeat extends SP_Singleton {
 		];
 
 		$this->maybe_schedule_cron();
-		add_filter( 'sp_ready', array( $this, 'is_ready' ) );
-		add_action( $this->cron_event, array( $this, 'check_beat' ) );
+		add_filter( 'sp_ready', [ $this, 'is_ready' ] );
+		add_action( $this->cron_event, [ $this, 'check_beat' ] );
 	}
 
 	/**
@@ -156,7 +156,7 @@ class SP_Heartbeat extends SP_Singleton {
 	 * @return bool
 	 */
 	protected function is_heartbeat_below_threshold( string $threshold, ?int $compared_to = null ): bool {
-		return ( $compared_to ?? time() ) - $this->last_beat['verified'] < $this->thresholds[ $threshold ];
+		return ( $compared_to ?? time() ) - $this->last_seen() < $this->thresholds[ $threshold ];
 	}
 
 	/**
@@ -165,7 +165,7 @@ class SP_Heartbeat extends SP_Singleton {
 	 * @return bool
 	 */
 	protected function is_heartbeat_stale(): bool {
-		return time() - $this->last_beat['queried'] > $this->intervals['stale'];
+		return time() - $this->get_last_beat()['queried'] > $this->intervals['stale'];
 	}
 
 	/**
@@ -176,8 +176,6 @@ class SP_Heartbeat extends SP_Singleton {
 	 */
 	public function has_pulse( string $threshold = 'shutdown' ): bool {
 		if ( $this->is_heartbeat_below_threshold( $threshold ) ) {
-//			var_dump(wp_debug_backtrace_summary());
-//			die('here');
 			return true;
 		} elseif ( is_admin() ) {
 			// There's no heartbeat, but this is an admin request, so query it now.

--- a/lib/class-sp-heartbeat.php
+++ b/lib/class-sp-heartbeat.php
@@ -13,23 +13,23 @@ class SP_Heartbeat extends SP_Singleton {
 	/**
 	 * What cluster statuses do we consider successful? Default is ['yellow', 'green'].
 	 *
-	 * @var array
+	 * @var array<string>
 	 */
-	public $healthy_statuses = array( 'yellow', 'green' );
+	public array $healthy_statuses = [ 'yellow', 'green' ];
 
 	/**
 	 * Store the intervals at which the heartbeat gets scheduled.
 	 *
-	 * @var array
+	 * @var array<string, int>
 	 */
-	public $intervals = array();
+	public array $intervals = [];
 
 	/**
-	 * Store the threshholds that we compare against our last heartbeat.
+	 * Store the thresholds that we compare against our last heartbeat.
 	 *
-	 * @var array
+	 * @var array<string, int>
 	 */
-	public $thresholds = array();
+	public array $thresholds = [];
 
 	/**
 	 * The action that the cron fires.
@@ -37,39 +37,39 @@ class SP_Heartbeat extends SP_Singleton {
 	 * @access protected
 	 * @var string
 	 */
-	protected $cron_event = 'sp_heartbeat';
+	protected string $cron_event = 'sp_heartbeat';
 
 	/**
 	 * Cached result of the heartbeat check.
 	 *
-	 * @access protected
-	 * @var boolean
+	 * @var null|'invalid'|'red'|'yellow'|'green'
 	 */
-	protected $beat_result;
+	public ?string $beat_result;
 
 	/**
 	 * Cached result of the time of last heartbeat.
 	 *
-	 * @var int
+	 * @var array<{ queried: int, verified: int }>
 	 */
-	protected $last_beat;
+	protected array $last_beat;
 
 	/**
-	 * Setup the singleton.
+	 * Set up the singleton.
 	 *
 	 * @codeCoverageIgnore
 	 */
-	public function setup() {
-		$this->intervals = array(
+	public function setup(): void {
+		$this->intervals = [
 			'heartbeat' => 5 * MINUTE_IN_SECONDS,
 			'increase'  => MINUTE_IN_SECONDS,
-		);
+			'stale'     => 10 * MINUTE_IN_SECONDS,
+		];
 
-		$this->thresholds = array(
+		$this->thresholds = [
 			'alert'    => 8 * MINUTE_IN_SECONDS,
 			'notify'   => 15 * MINUTE_IN_SECONDS,
 			'shutdown' => 15 * MINUTE_IN_SECONDS,
-		);
+		];
 
 		$this->maybe_schedule_cron();
 		add_filter( 'sp_ready', array( $this, 'is_ready' ) );
@@ -79,65 +79,115 @@ class SP_Heartbeat extends SP_Singleton {
 	/**
 	 * Check the status from Elasticsearch.
 	 *
-	 * @param  boolean $force Optional. If true, bypasses local cache and
-	 *                        re-checks the heartbeat from ES.
+	 * @param bool $force Optional. If true, bypasses local cache and re-checks the heartbeat from ES.
 	 * @return bool true on success or false on failure.
 	 */
-	public function check_beat( $force = false ) {
+	public function check_beat( bool $force = false ): bool {
 		// Ensure we only check the beat once per request.
+		$checked = false;
 		if ( $force || ! isset( $this->beat_result ) ) {
 			$health            = SP_API()->cluster_health();
-			$this->beat_result = ( ! empty( $health->status ) && in_array( $health->status, $this->healthy_statuses, true ) );
-			if ( $this->beat_result ) {
+			$this->beat_result = ! empty( $health->status ) ? $health->status : 'invalid';
+			$checked           = true;
+		}
+
+		// Verify the beat is healthy.
+		$has_healthy_beat = in_array( $this->beat_result, $this->healthy_statuses, true );
+
+		if ( $checked ) {
+			if ( $has_healthy_beat ) {
 				$this->record_pulse();
 			} else {
+				$this->record_pulse( $this->last_seen() );
 				$this->call_nurse();
 			}
 		}
 
-		return $this->beat_result;
+		return $has_healthy_beat;
 	}
 
 	/**
 	 * Get the last recorded beat.
 	 *
-	 * @param  boolean $force Optional. If true, bypass the local cache and
-	 *                        get the value from the option.
-	 * @return int The time of the last beat, or 0 if one has not been recorded.
+	 * @param  bool $force Optional. If true, bypass the local cache and get the value from the option.
+	 * @return array<{queried: int, verified: int}> The times the last time the beat was queried and verified.
 	 */
-	public function get_last_beat( $force = false ) {
+	public function get_last_beat( bool $force = false ): array {
 		if ( $force || ! isset( $this->last_beat ) ) {
-			$this->last_beat = intval( get_option( 'sp_heartbeat' ) );
+			$beat = get_option( 'sp_heartbeat' );
+			if ( is_array( $beat ) ) {
+				$this->last_beat = $beat;
+			} elseif ( is_numeric( $beat ) ) {
+				// The heartbeat needs to be migrated from the old format.
+				$this->record_pulse( $beat, $beat );
+			} else {
+				// No heartbeat, zero out the heartbeat.
+				$this->last_beat = [
+					'queried'  => 0,
+					'verified' => 0,
+				];
+			}
 		}
 		return $this->last_beat;
+	}
+
+	/**
+	 * Get the last time the heartbeat was verified.
+	 *
+	 * @return int
+	 */
+	public function last_seen(): int {
+		return $this->get_last_beat()['verified'];
 	}
 
 	/**
 	 * Record that we missed a beat. Presently, this means rescheduling the cron
 	 * at the 'increase' checkin rate.
 	 */
-	protected function call_nurse() {
+	protected function call_nurse(): void {
 		$this->reschedule_cron( 'increase' );
+	}
+
+	/**
+	 * Check if the heartbeat is below the given threshold.
+	 *
+	 * @param string   $threshold   One of SP_Heartbeat::thresholds.
+	 * @param int|null $compared_to Optional. Time to which to compare. Defaults to now.
+	 * @return bool
+	 */
+	protected function is_heartbeat_below_threshold( string $threshold, ?int $compared_to = null ): bool {
+		return ( $compared_to ?? time() ) - $this->last_beat['verified'] < $this->thresholds[ $threshold ];
+	}
+
+	/**
+	 * Check if the heartbeat is stale (has not been checked recently).
+	 *
+	 * @return bool
+	 */
+	protected function is_heartbeat_stale(): bool {
+		return time() - $this->last_beat['queried'] > $this->intervals['stale'];
 	}
 
 	/**
 	 * Check if SearchPress has a pulse within the provided threshold.
 	 *
-	 * @param  string $threshold Optional. One of SP_Heartbeat::thresholds.
-	 *                           Defaults to 'shutdown'.
-	 * @return boolean
+	 * @param string $threshold Optional. One of SP_Heartbeat::thresholds. Defaults to 'shutdown'.
+	 * @return bool
 	 */
-	public function has_pulse( $threshold = 'shutdown' ) {
-		$last_beat = $this->get_last_beat();
-		if ( time() - $last_beat < $this->thresholds[ $threshold ] ) {
+	public function has_pulse( string $threshold = 'shutdown' ): bool {
+		if ( $this->is_heartbeat_below_threshold( $threshold ) ) {
+//			var_dump(wp_debug_backtrace_summary());
+//			die('here');
 			return true;
-		} else {
+		} elseif ( is_admin() ) {
+			// There's no heartbeat, but this is an admin request, so query it now.
 			$this->check_beat();
-			// If we updated the pulse, run this again.
-			if ( $last_beat !== $this->get_last_beat() ) {
-				return $this->has_pulse( $threshold );
-			}
+			return $this->is_heartbeat_below_threshold( $threshold );
+		} elseif ( $this->is_heartbeat_stale() ) {
+			// If the heartbeat is stale, check the last known status.
+			return $this->is_heartbeat_below_threshold( $threshold, $this->get_last_beat()['queried'] );
 		}
+
 		return false;
 	}
 
@@ -145,12 +195,12 @@ class SP_Heartbeat extends SP_Singleton {
 	 * Is SearchPress ready for requests? This is added to the `sp_ready`
 	 * filter.
 	 *
-	 * @param  bool|null $ready Value passed from other methods.
-	 * @return boolean
+	 * @param bool|null $ready Value passed from other methods.
+	 * @return bool
 	 */
-	public function is_ready( $ready ) {
+	public function is_ready( ?bool $ready ): bool {
 		if ( false === $ready ) {
-			return $ready;
+			return false;
 		}
 
 		return SP_Config()->active() && $this->has_pulse();
@@ -158,9 +208,15 @@ class SP_Heartbeat extends SP_Singleton {
 
 	/**
 	 * Record a successful heartbeat.
+	 *
+	 * @param int|null $verified Optional. The time of the last successful heartbeat response.
+	 * @param int|null $queried Optional. The time of the last heartbeat request.
 	 */
-	public function record_pulse() {
-		$this->last_beat = time();
+	public function record_pulse( ?int $verified = null, ?int $queried = null ): void {
+		$this->last_beat = [
+			'queried'  => $queried ?? time(),
+			'verified' => $verified ?? time(),
+		];
 		update_option( 'sp_heartbeat', $this->last_beat );
 		$this->reschedule_cron();
 	}
@@ -170,7 +226,7 @@ class SP_Heartbeat extends SP_Singleton {
 	 *
 	 * @codeCoverageIgnore
 	 */
-	protected function maybe_schedule_cron() {
+	protected function maybe_schedule_cron(): void {
 		if ( ! wp_next_scheduled( $this->cron_event ) ) {
 			wp_schedule_single_event( time() + $this->intervals['heartbeat'], $this->cron_event );
 		}
@@ -179,10 +235,10 @@ class SP_Heartbeat extends SP_Singleton {
 	/**
 	 * Reschedules the cron event at the given interval from now.
 	 *
-	 * @param  string $interval Time from now to schedule the heartbeat.
+	 * @param string $interval Time from now to schedule the heartbeat.
 	 *                          possible values are in SP_Heartbeat::intervals.
 	 */
-	protected function reschedule_cron( $interval = 'heartbeat' ) {
+	protected function reschedule_cron( string $interval = 'heartbeat' ): void {
 		wp_clear_scheduled_hook( $this->cron_event );
 		wp_schedule_single_event( time() + $this->intervals[ $interval ], $this->cron_event );
 	}
@@ -190,17 +246,16 @@ class SP_Heartbeat extends SP_Singleton {
 	/**
 	 * Get the current heartbeat status.
 	 *
-	 * @return string Possible values are 'never', 'alert', 'shutdown', and 'ok'.
+	 * @return 'never'|'alert'|'shutdown'|'ok'|'stale'
 	 */
-	public function get_status() {
-		$last_beat = $this->get_last_beat();
-		if ( ! $last_beat ) {
+	public function get_status(): string {
+		if ( ! $this->last_seen() ) {
 			return 'never';
-		}
-		$diff = time() - $last_beat;
-		if ( $diff < $this->thresholds['alert'] ) {
+		} elseif ( $this->is_heartbeat_stale() ) {
+			return 'stale';
+		} elseif ( $this->is_heartbeat_below_threshold( 'alert' ) ) {
 			return 'ok';
-		} elseif ( $diff < $this->thresholds['shutdown'] ) {
+		} elseif ( $this->is_heartbeat_below_threshold( 'shutdown' ) ) {
 			return 'alert';
 		} else {
 			return 'shutdown';
@@ -211,9 +266,9 @@ class SP_Heartbeat extends SP_Singleton {
 /**
  * Initializes and returns the instance of the SP_Heartbeat class.
  *
- * @return SP_Singleton The initialized instance of the SP_Heartbeat class.
+ * @return SP_Heartbeat The initialized instance of the SP_Heartbeat class.
  */
-function SP_Heartbeat() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
+function SP_Heartbeat(): SP_Heartbeat { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.FunctionNameInvalid
 	return SP_Heartbeat::instance();
 }
 add_action( 'after_setup_theme', 'SP_Heartbeat', 20 );

--- a/lib/class-sp-singleton.php
+++ b/lib/class-sp-singleton.php
@@ -6,15 +6,17 @@
  */
 
 /**
- * Base Singleton Class
+ * Base Singleton Class.
+ *
+ * @template Instance of static
  */
 abstract class SP_Singleton {
 	/**
 	 * Holds references to the singleton instances.
 	 *
-	 * @var array
+	 * @var array<Instance>
 	 */
-	private static $instances;
+	private static array $instances;
 
 	/**
 	 * Ensure singletons can't be instantiated outside the `instance()` method.
@@ -26,12 +28,12 @@ abstract class SP_Singleton {
 	/**
 	 * Get an instance of the class.
 	 *
-	 * @return SP_Singleton
+	 * @return Instance
 	 */
 	public static function instance() {
 		$class_name = get_called_class();
 		if ( ! isset( self::$instances[ $class_name ] ) ) {
-			self::$instances[ $class_name ] = new $class_name();
+			self::$instances[ $class_name ] = new static();
 			self::$instances[ $class_name ]->setup();
 		}
 		return self::$instances[ $class_name ];

--- a/searchpress.php
+++ b/searchpress.php
@@ -3,7 +3,7 @@
  * Plugin Name: SearchPress
  * Plugin URI: http://searchpress.org
  * Description: Elasticsearch integration for WordPress.
- * Version: 0.5.1
+ * Version: 0.5.2
  * Author: Matthew Boynes, Alley Interactive
  * Author URI: https://alley.com
  *

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -425,7 +425,7 @@ class Tests_Admin extends SearchPress_UnitTestCase {
 	 * @group stale-heartbeat
 	 */
 	public function test_admin_notices_heartbeat_stale() {
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ) ] );
 		$time = time() - SP_Heartbeat()->thresholds['shutdown'] - 10;
 		SP_Heartbeat()->record_pulse( $time, $time );
 		$this->assertSame( 'stale', SP_Heartbeat()->get_status() );
@@ -436,7 +436,7 @@ class Tests_Admin extends SearchPress_UnitTestCase {
 	 * @group stale-heartbeat
 	 */
 	public function test_stale_heartbeat_rechecks_in_admin_screen() {
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 		$time = time() - SP_Heartbeat()->thresholds['shutdown'] - 10;
 		SP_Heartbeat()->record_pulse( $time, $time );
 		$this->assertSame( 'stale', SP_Heartbeat()->get_status() );

--- a/tests/test-admin.php
+++ b/tests/test-admin.php
@@ -425,7 +425,7 @@ class Tests_Admin extends SearchPress_UnitTestCase {
 	 * @group stale-heartbeat
 	 */
 	public function test_admin_notices_heartbeat_stale() {
-		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ) ] );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 		$time = time() - SP_Heartbeat()->thresholds['shutdown'] - 10;
 		SP_Heartbeat()->record_pulse( $time, $time );
 		$this->assertSame( 'stale', SP_Heartbeat()->get_status() );

--- a/tests/test-heartbeat.php
+++ b/tests/test-heartbeat.php
@@ -145,7 +145,7 @@ class Tests_Heartbeat extends SearchPress_UnitTestCase {
 	 * @group stale-heartbeat
 	 */
 	public function test_stale_heartbeat_rechecks_in_non_admin_screen() {
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 		$this->assertFalse( is_admin() );
 
 		$time = time() - SP_Heartbeat()->thresholds['shutdown'] - 10;


### PR DESCRIPTION
* **POSSIBLE BREAKING CHANGE** Refactors `SP_Heartbeat` to store the last time the beat was checked as well as the last time the beat was verified. `SP_Heartbeat::get_last_beat()` previously returned an int, but now returns an array.
* Includes assorted improvements for IDE static analysis.

Resolves #61, #62
